### PR TITLE
switch newline print order

### DIFF
--- a/R/BayesianOptimization.R
+++ b/R/BayesianOptimization.R
@@ -151,7 +151,7 @@ BayesianOptimization <- function(FUN, bounds, init_grid_dt = NULL, init_points =
               format(DT_history[i, "Round", with = FALSE], trim = FALSE, digits = 0, nsmall = 0),
               format(DT_history[i, -"Round", with = FALSE], trim = FALSE, digits = 0, nsmall = 4)),
             sep = " = ", collapse = "\t") %>%
-        cat(., "\n")
+        cat("\n", .)
     }
   }
   # Optimization


### PR DESCRIPTION
When intermediate output prints to console first, the first `cat` output here will be bunched up.

(I have a `FUN` that will produce a warning on the first run; the diagnostics printed directly after the warning message (warnings don't come with final newlines)